### PR TITLE
Service test/find data

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ https://github.com/users/sugao-2211/projects/1
     - id「4」で検索
 - パスパラメータ(id)の検索における例外処理
     - id「9」で検索し例外処理を発生
-- findByIdメソッド()(パスパラメータ検索)のService単体テスト
+- findById()メソッド(パスパラメータ検索)のService単体テスト
     - 存在する在庫のidをパスパラメータに指定したときに正常に在庫の情報が返されること
     - 存在しないIDをパスパラメータに指定したときにNotFoundExceptionが返されること
-    - 存在しないIDをパスパラメータに指定し例外が発生したときに期待した例外ハンドリングが返されること(NotFoundException = "data not found")
+- findData()メソッド(クエリパラメータ検索)のService単体テスト
+    - クエリパラメータを指定しなかったときにfindAllメソッドが呼び出されること
+    - 存在する名前をクエリパラメータに指定したときにfindByNameメソッドが呼び出されること
+    - 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること
 
 ##
 
@@ -145,9 +148,9 @@ https://github.com/users/sugao-2211/projects/1
 ##
 
 <details>
-<summary>findByIdメソッド()(パスパラメータ検索)のService単体テスト</summary>
+<summary>findById()メソッド(パスパラメータ検索)のService単体テスト</summary>
 
-- findByIdメソッド()(パスパラメータ検索)のService単体テスト
+- findById()メソッド(パスパラメータ検索)のService単体テスト
     - 存在する在庫のidをパスパラメータに指定したときに正常に在庫の情報が返されること
     - 存在しないIDをパスパラメータに指定したときにNotFoundExceptionが返されること
 
@@ -161,19 +164,19 @@ https://github.com/users/sugao-2211/projects/1
 ##
 
 <details>
-<summary>findDataメソッド()(クエリパラメータ検索)のService単体テスト</summary>
+<summary>findData()メソッド(クエリパラメータ検索)のService単体テスト</summary>
 
-- findByIdメソッド()(パスパラメータ検索)のService単体テスト
-    - クエリパラメータを指定しなかったときにfindAllメソッドが呼び出されること
-    - 存在する名前をクエリパラメータに指定したときにfindByNameメソッドが呼び出されること
+- findData()メソッド(クエリパラメータ検索)のService単体テスト
+    - クエリパラメータを指定しなかったときにfindAll()メソッドが呼び出されること
+    - 存在する名前をクエリパラメータに指定したときにfindByName()メソッドが呼び出されること
     - 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること
 
-  https://github.com/sugao-2211/stockListProject/blob/e8d7c8dd4d7a8342de67f6051d5ed96f452e8fd8/src/test/java/com/stock/stocklist/service/StockListServiceTest.java#L52-L88
+  https://github.com/sugao-2211/stockListProject/blob/563beb0a6b24b06830bc7f2139ad1769a67e35f0/src/test/java/com/stock/stocklist/service/StockListServiceTest.java#L52-L89
 
 - 実行結果
-    - クエリパラメータを指定しなかったときにfindAllメソッドが呼び出されること
+    - クエリパラメータを指定しなかったときにfindAll()メソッドが呼び出されること
       <img width="1373" alt="スクリーンショット 2023-12-13 10 56 07" src="https://github.com/sugao-2211/stockListProject/assets/141313076/d63495d2-e7ed-46fe-be2b-5bd4a214aa6b">
-    - 存在する名前をクエリパラメータに指定したときにfindByNameメソッドが呼び出されること
+    - 存在する名前をクエリパラメータに指定したときにfindByName()メソッドが呼び出されること
       <img width="1380" alt="スクリーンショット 2023-12-13 10 56 29" src="https://github.com/sugao-2211/stockListProject/assets/141313076/a394563c-2254-4620-9f19-8fe864001f6b">
     - 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること
       <img width="1373" alt="スクリーンショット 2023-12-13 10 56 07" src="https://github.com/sugao-2211/stockListProject/assets/141313076/d63495d2-e7ed-46fe-be2b-5bd4a214aa6b">

--- a/README.md
+++ b/README.md
@@ -150,12 +150,33 @@ https://github.com/users/sugao-2211/projects/1
 - findByIdメソッド()(パスパラメータ検索)のService単体テスト
     - 存在する在庫のidをパスパラメータに指定したときに正常に在庫の情報が返されること
     - 存在しないIDをパスパラメータに指定したときにNotFoundExceptionが返されること
-    - 存在しないIDをパスパラメータに指定し例外が発生したときに期待した例外ハンドリングが返されること(NotFoundException = "data not found")
 
   https://github.com/sugao-2211/stockListProject/blob/e8d7c8dd4d7a8342de67f6051d5ed96f452e8fd8/src/test/java/com/stock/stocklist/service/StockListServiceTest.java#L1-L59
 
 - 実行結果
   <img width="1426" alt="スクリーンショット 2023-12-04 17 55 18" src="https://github.com/sugao-2211/stockListProject/assets/141313076/7714bc6c-6570-4908-9aca-1a2ae50341d8">
+
+</details>
+
+##
+
+<details>
+<summary>findDataメソッド()(クエリパラメータ検索)のService単体テスト</summary>
+
+- findByIdメソッド()(パスパラメータ検索)のService単体テスト
+    - クエリパラメータを指定しなかったときにfindAllメソッドが呼び出されること
+    - 存在する名前をクエリパラメータに指定したときにfindByNameメソッドが呼び出されること
+    - 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること
+
+  https://github.com/sugao-2211/stockListProject/blob/e8d7c8dd4d7a8342de67f6051d5ed96f452e8fd8/src/test/java/com/stock/stocklist/service/StockListServiceTest.java#L52-L88
+
+- 実行結果
+    - クエリパラメータを指定しなかったときにfindAllメソッドが呼び出されること
+      <img width="1373" alt="スクリーンショット 2023-12-13 10 56 07" src="https://github.com/sugao-2211/stockListProject/assets/141313076/d63495d2-e7ed-46fe-be2b-5bd4a214aa6b">
+    - 存在する名前をクエリパラメータに指定したときにfindByNameメソッドが呼び出されること
+      <img width="1380" alt="スクリーンショット 2023-12-13 10 56 29" src="https://github.com/sugao-2211/stockListProject/assets/141313076/a394563c-2254-4620-9f19-8fe864001f6b">
+    - 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること
+      <img width="1373" alt="スクリーンショット 2023-12-13 10 56 07" src="https://github.com/sugao-2211/stockListProject/assets/141313076/d63495d2-e7ed-46fe-be2b-5bd4a214aa6b">
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -167,19 +167,19 @@ https://github.com/users/sugao-2211/projects/1
 <summary>findData()メソッド(クエリパラメータ検索)のService単体テスト</summary>
 
 - findData()メソッド(クエリパラメータ検索)のService単体テスト
-    - クエリパラメータを指定しなかったときにfindAll()メソッドが呼び出されること
-    - 存在する名前をクエリパラメータに指定したときにfindByName()メソッドが呼び出されること
-    - 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること
+    - 在庫の名前を指定しなかったときにfindAllメソッド呼び出されて全件の在庫情報が返却されること
+    - 存在する名前を指定したときにfindByNameメソッドが呼び出されて該当する在庫情報が返却されること
+    - 存在しない名前を指定したときに空のListが返されること
 
-  https://github.com/sugao-2211/stockListProject/blob/563beb0a6b24b06830bc7f2139ad1769a67e35f0/src/test/java/com/stock/stocklist/service/StockListServiceTest.java#L52-L89
+  https://github.com/sugao-2211/stockListProject/blob/dac5df8cb3816a8ec91aad88ea8d47a3b48f2b52/src/test/java/com/stock/stocklist/service/StockListServiceTest.java#L52-L91
 
 - 実行結果
-    - クエリパラメータを指定しなかったときにfindAll()メソッドが呼び出されること
+    - 在庫の名前を指定しなかったときにfindAllメソッド呼び出されて全件の在庫情報が返却されること
       <img width="1373" alt="スクリーンショット 2023-12-13 10 56 07" src="https://github.com/sugao-2211/stockListProject/assets/141313076/d63495d2-e7ed-46fe-be2b-5bd4a214aa6b">
-    - 存在する名前をクエリパラメータに指定したときにfindByName()メソッドが呼び出されること
+    - 存在する名前を指定したときにfindByNameメソッドが呼び出されて該当する在庫情報が返却されること
       <img width="1380" alt="スクリーンショット 2023-12-13 10 56 29" src="https://github.com/sugao-2211/stockListProject/assets/141313076/a394563c-2254-4620-9f19-8fe864001f6b">
-    - 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること
-      <img width="1373" alt="スクリーンショット 2023-12-13 10 56 07" src="https://github.com/sugao-2211/stockListProject/assets/141313076/d63495d2-e7ed-46fe-be2b-5bd4a214aa6b">
+    - 存在しない名前を指定したときに空のListが返されること
+      <img width="1362" alt="スクリーンショット 2023-12-14 15 39 45" src="https://github.com/sugao-2211/stockListProject/assets/141313076/e893ad2f-ff4e-4909-be49-2f5f541381d2">
 
 </details>
 

--- a/src/main/java/com/stock/stocklist/controller/StockListController.java
+++ b/src/main/java/com/stock/stocklist/controller/StockListController.java
@@ -36,15 +36,15 @@ public class StockListController {
 
     @GetMapping("/stockList/{id}")
     public ResponseEntity<StockListResponse> partData(@PathVariable int id) {
-        StockList getData = stockListService.findById(id);
-        StockListResponse partData = new StockListResponse(getData);
+        StockList stockList = stockListService.findById(id);
+        StockListResponse partData = new StockListResponse(stockList);
         return ResponseEntity.ok(partData);
     }
 
     @PostMapping("/stockList")
     public ResponseEntity<MessageResponse> insert(@RequestBody @Validated InsertRequest insertRequest, UriComponentsBuilder uriComponentsBuilder) {
-        StockList insertData = stockListService.insert(insertRequest.convertToStockList());
-        URI uri = uriComponentsBuilder.path("/stockList/{id}").buildAndExpand(insertData.getId()).toUri();
+        StockList stockList = stockListService.insert(insertRequest.convertToStockList());
+        URI uri = uriComponentsBuilder.path("/stockList/{id}").buildAndExpand(stockList.getId()).toUri();
         MessageResponse message = new MessageResponse("new data created");
         return ResponseEntity.created(uri).body(message);
     }

--- a/src/main/java/com/stock/stocklist/controller/StockListController.java
+++ b/src/main/java/com/stock/stocklist/controller/StockListController.java
@@ -30,8 +30,8 @@ public class StockListController {
     @GetMapping("/stockList")
     public ResponseEntity<List<StockListResponse>> findData(String name) {
         List<StockList> stockList = stockListService.findData(name);
-        List<StockListResponse> AllData = stockList.stream().map(StockListResponse::new).toList();
-        return ResponseEntity.ok(AllData);
+        List<StockListResponse> allData = stockList.stream().map(StockListResponse::new).toList();
+        return ResponseEntity.ok(allData);
     }
 
     @GetMapping("/stockList/{id}")

--- a/src/main/java/com/stock/stocklist/controller/StockListController.java
+++ b/src/main/java/com/stock/stocklist/controller/StockListController.java
@@ -29,9 +29,9 @@ public class StockListController {
 
     @GetMapping("/stockList")
     public ResponseEntity<List<StockListResponse>> findData(String name) {
-        List<StockList> getData = stockListService.findData(name);
-        List<StockListResponse> findData = getData.stream().map(StockListResponse::new).toList();
-        return ResponseEntity.ok(findData);
+        List<StockList> stockList = stockListService.findData(name);
+        List<StockListResponse> AllData = stockList.stream().map(StockListResponse::new).toList();
+        return ResponseEntity.ok(AllData);
     }
 
     @GetMapping("/stockList/{id}")

--- a/src/main/java/com/stock/stocklist/service/StockListService.java
+++ b/src/main/java/com/stock/stocklist/service/StockListService.java
@@ -22,9 +22,6 @@ public class StockListService {
             stockList = stockListMapper.findAll();
         } else {
             stockList = stockListMapper.findByName(name);
-            if (stockList.isEmpty()) {
-                throw new NotFoundException("data not found");
-            }
         }
         return stockList;
     }

--- a/src/main/java/com/stock/stocklist/service/StockListService.java
+++ b/src/main/java/com/stock/stocklist/service/StockListService.java
@@ -17,16 +17,16 @@ public class StockListService {
     private final StockListMapper stockListMapper;
 
     public List<StockList> findData(String name) {
-        List<StockList> getData;
+        List<StockList> stockList;
         if (Objects.isNull(name)) {
-            getData = stockListMapper.findAll();
+            stockList = stockListMapper.findAll();
         } else {
-            getData = stockListMapper.findByName(name);
-            if (getData.isEmpty()) {
+            stockList = stockListMapper.findByName(name);
+            if (stockList.isEmpty()) {
                 throw new NotFoundException("data not found");
             }
         }
-        return getData;
+        return stockList;
     }
 
     public StockList findById(int id) {

--- a/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
+++ b/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
@@ -10,11 +10,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -46,5 +48,21 @@ class StockListServiceTest {
         verify(stockListMapper, times(1)).findById(99);
     }
 
+    @Test
+    public void クエリパラメータを指定しなかったときにfindAllメソッドが呼び出されること() throws Exception {
+        List<StockList> stockList = List.of(
+                new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.parse("2023-05-24")),
+                new StockList(2, "塩化カリウム", "特級", 500, "g", LocalDate.parse("2023-07-19")),
+                new StockList(3, "硫酸ナトリウム", "特級", 5, "kg", LocalDate.parse("2023-10-11"))
+        );
+
+        doReturn(stockList).when(stockListMapper).findAll();
+
+        List<StockList> actual = stockListService.findData(null);
+        assertThat(actual).isEqualTo(stockList);
+        verify(stockListMapper, times(1)).findAll();
+        verify(stockListMapper, never()).findByName("メタノール");
+
+    }
 
 }

--- a/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
+++ b/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
@@ -65,4 +65,16 @@ class StockListServiceTest {
 
     }
 
+    @Test
+    public void 存在する名前をクエリパラメータに指定したときにfindByNameメソッドが呼び出されること() throws Exception {
+        doReturn(List.of(new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.parse("2023-05-24"))))
+                .when(stockListMapper).findByName("メタノール");
+
+        List<StockList> actual = stockListService.findData("メタノール");
+
+        assertThat(actual).isEqualTo(List.of(new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.parse("2023-05-24"))));
+        verify(stockListMapper, times(1)).findByName("メタノール");
+        verify(stockListMapper, never()).findAll();
+    }
+
 }

--- a/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
+++ b/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
@@ -46,4 +46,5 @@ class StockListServiceTest {
         verify(stockListMapper, times(1)).findById(99);
     }
 
+
 }

--- a/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
+++ b/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -75,6 +76,15 @@ class StockListServiceTest {
         assertThat(actual).isEqualTo(List.of(new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.parse("2023-05-24"))));
         verify(stockListMapper, times(1)).findByName("メタノール");
         verify(stockListMapper, never()).findAll();
+    }
+
+    @Test
+    public void 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること() throws Exception {
+        doReturn(Collections.emptyList()).when(stockListMapper).findByName("硫酸カリウム");
+        assertThrows(NotFoundException.class, () -> {
+            stockListService.findData("硫酸カリウム");
+        });
+        verify(stockListMapper, times(1)).findByName("硫酸カリウム");
     }
 
 }

--- a/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
+++ b/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
@@ -50,7 +50,7 @@ class StockListServiceTest {
     }
 
     @Test
-    public void クエリパラメータを指定しなかったときにfindAllメソッドが呼び出されること() throws Exception {
+    public void 在庫の名前を指定しなかったときにfindAllメソッド呼び出されて全件の在庫情報が返却されること() throws Exception {
         List<StockList> stockList = List.of(
                 new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.parse("2023-05-24")),
                 new StockList(2, "塩化カリウム", "特級", 500, "g", LocalDate.parse("2023-07-19")),
@@ -67,7 +67,7 @@ class StockListServiceTest {
     }
 
     @Test
-    public void 存在する名前をクエリパラメータに指定したときにfindByNameメソッドが呼び出されること() throws Exception {
+    public void 存在する名前を指定したときにfindByNameメソッドが呼び出されて該当する在庫情報が返却されること() throws Exception {
         doReturn(List.of(new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.parse("2023-05-24"))))
                 .when(stockListMapper).findByName("メタノール");
 

--- a/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
+++ b/src/test/java/com/stock/stocklist/service/StockListServiceTest.java
@@ -79,12 +79,14 @@ class StockListServiceTest {
     }
 
     @Test
-    public void 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること() throws Exception {
-        doReturn(Collections.emptyList()).when(stockListMapper).findByName("硫酸カリウム");
-        assertThrows(NotFoundException.class, () -> {
-            stockListService.findData("硫酸カリウム");
-        });
-        verify(stockListMapper, times(1)).findByName("硫酸カリウム");
+    public void 存在しない名前を指定したときに空のListが返されること() throws Exception {
+        doReturn(Collections.emptyList()).when(stockListMapper).findByName("硝酸");
+
+        List<StockList> actual = stockListService.findData("硝酸");
+        assertThat(actual).isEqualTo(Collections.emptyList());
+
+        verify(stockListMapper, times(1)).findByName("硝酸");
+        verify(stockListMapper, never()).findAll();
     }
 
 }


### PR DESCRIPTION
## CRUD処理すべてを備えたREST APIの作成

### 概要

消耗品の在庫一覧についてAPIを作成しました。  
今回は試験研究などで使用される試薬を題材にして在庫一覧表を作成しました。

今回はServiceのfindData()メソッドの単体テストになります。
[コミット一覧](https://github.com/sugao-2211/stockListProject/pull/15/commits)

##

これまでの実施結果はこちら
https://github.com/sugao-2211/stockListProject/blob/main/README.md
##

プロジェクトの進捗を作成しました。(作業しながら作成中)
https://github.com/users/sugao-2211/projects/1

##

今回実施箇所
- findDataメソッド()(クエリパラメータ検索)のService単体テスト
 1. "クエリパラメータを指定しなかったときにfindAll()メソッドが呼び出されること
 2. "存在する名前をクエリパラメータに指定したときにfindByName()メソッドが呼び出されること
 3. "存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること"について、テストコードを記述する。(findByName()メソッド/NotFoundException)

- ServiceTestクラス  
  https://github.com/sugao-2211/stockListProject/blob/761ae46370d1cfcd7fef040c7dc26a1bb7131111/src/test/java/com/stock/stocklist/service/StockListServiceTest.java#L1-L90

- Serviceクラス(確認用)←testコードを確認するために必要かと思い載せいていますが変更は加えていません。  
  https://github.com/sugao-2211/stockListProject/blob/761ae46370d1cfcd7fef040c7dc26a1bb7131111/src/main/java/com/stock/stocklist/service/StockListService.java#L1-L61


- 実行結果
  - クエリパラメータを指定しなかったときにfindAllメソッドが呼び出されること
    <img width="1373" alt="スクリーンショット 2023-12-13 10 56 07" src="https://github.com/sugao-2211/stockListProject/assets/141313076/d63495d2-e7ed-46fe-be2b-5bd4a214aa6b">

  - 存在する名前をクエリパラメータに指定したときにfindByNameメソッドが呼び出されること
    <img width="1380" alt="スクリーンショット 2023-12-13 10 56 29" src="https://github.com/sugao-2211/stockListProject/assets/141313076/a394563c-2254-4620-9f19-8fe864001f6b">

  - 存在しない名前をクエリパラメータに指定したときにNotFoundExceptionが返されること
    <img width="1373" alt="スクリーンショット 2023-12-13 10 56 07" src="https://github.com/sugao-2211/stockListProject/assets/141313076/d63495d2-e7ed-46fe-be2b-5bd4a214aa6b">

##
今回の実施結果を下記のREADMEにも反映しています。
("Read処理の実装"の中にあります。)
https://github.com/sugao-2211/stockListProject/blob/f597a3f694b8160e357778105c02bebc957ed90b/README.md
