### PR TITLE
DBtest/findByName

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ https://github.com/users/sugao-2211/projects/1
 <summary>findAll()メソッドのDB単体テスト</summary>
 
 - findAll()メソッドのDB単体テスト
-    - findAll()メソッドによって全件の在庫情報が返却されること
+    - findAll()メソッドによって全件の在庫情報が取得できること
 
   https://github.com/sugao-2211/stockListProject/blob/a3fc05a918a62fcfa01414b7aa416d632f9bc833/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java#L1-L42
   https://github.com/sugao-2211/stockListProject/blob/38da884c0443afb05d3d58d154dc0cdb322ab945/src/test/resources/datasets/stockList.yml#L1-L37
@@ -201,6 +201,24 @@ https://github.com/users/sugao-2211/projects/1
 
 </details>
 
+##
+
+<details>
+<summary>findByName()メソッドのDB単体テスト</summary>
+
+- findByName()メソッドのDB単体テスト
+    - 在庫名を指定したときに該当するの在庫情報が取得できること
+    - 存在しない在庫を指定したときに空のリストが返されること
+
+  https://github.com/sugao-2211/stockListProject/blob/4a1c4063201ef38414f2568a0cb9ebcdc9b49825/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java#L42-L58
+
+- 実行結果
+    - 在庫名を指定したときに該当するの在庫情報が取得できること
+      <img width="1391" alt="スクリーンショット 2023-12-17 16 19 03" src="https://github.com/sugao-2211/stockListProject/assets/141313076/89714d1e-e855-42f9-9c0d-0e2ab244e634">
+    - 存在しない在庫を指定したときに空のリストが返されること
+      <img width="1383" alt="スクリーンショット 2023-12-17 16 24 05" src="https://github.com/sugao-2211/stockListProject/assets/141313076/fe32ee08-a1d7-4c22-a44f-089751b9fb1f">
+
+</details>
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -208,14 +208,14 @@ https://github.com/users/sugao-2211/projects/1
 
 - findByName()メソッドのDB単体テスト
     - 在庫名を指定したときに該当するの在庫情報が取得できること
-    - 存在しない在庫を指定したときに空のリストが返されること
+    - 存在しない在庫名を指定したときに空のリストが返されること
 
   https://github.com/sugao-2211/stockListProject/blob/4a1c4063201ef38414f2568a0cb9ebcdc9b49825/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java#L42-L58
 
 - 実行結果
     - 在庫名を指定したときに該当するの在庫情報が取得できること
       <img width="1391" alt="スクリーンショット 2023-12-17 16 19 03" src="https://github.com/sugao-2211/stockListProject/assets/141313076/89714d1e-e855-42f9-9c0d-0e2ab244e634">
-    - 存在しない在庫を指定したときに空のリストが返されること
+    - 存在しない在庫名を指定したときに空のリストが返されること
       <img width="1383" alt="スクリーンショット 2023-12-17 16 24 05" src="https://github.com/sugao-2211/stockListProject/assets/141313076/fe32ee08-a1d7-4c22-a44f-089751b9fb1f">
 
 </details>

--- a/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java
+++ b/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java
@@ -39,4 +39,13 @@ class StockListMapperTest {
                 );
     }
 
+    @Test
+    @DataSet(value = "datasets/stockList.yml")
+    @Transactional
+    void 在庫名を指定した時に該当する在庫情報が取得できること() {
+        List<StockList> stockList = stockListMapper.findByName("メタノール");
+        assertThat(stockList)
+                .contains(new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.of(2023, 5, 24)));
+    }
+
 }

--- a/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java
+++ b/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java
@@ -51,7 +51,7 @@ class StockListMapperTest {
     @Test
     @DataSet(value = "datasets/stockList.yml")
     @Transactional
-    void 存在しない在庫を指定したときに空のリストが返されること() {
+    void 存在しない在庫名を指定したときに空のリストが返されること() {
         List<StockList> stockList = stockListMapper.findByName("硝酸");
         assertThat(stockList).isEmpty();
     }

--- a/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java
+++ b/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java
@@ -42,7 +42,7 @@ class StockListMapperTest {
     @Test
     @DataSet(value = "datasets/stockList.yml")
     @Transactional
-    void 在庫名を指定した時に該当する在庫情報が取得できること() {
+    void 在庫名を指定したときに該当する在庫情報が取得できること() {
         List<StockList> stockList = stockListMapper.findByName("メタノール");
         assertThat(stockList)
                 .contains(new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.of(2023, 5, 24)));
@@ -51,7 +51,7 @@ class StockListMapperTest {
     @Test
     @DataSet(value = "datasets/stockList.yml")
     @Transactional
-    void 存在しない在庫を指定した時に空のリストが返されること() {
+    void 存在しない在庫を指定したときに空のリストが返されること() {
         List<StockList> stockList = stockListMapper.findByName("硝酸");
         assertThat(stockList).isEmpty();
     }

--- a/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java
+++ b/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java
@@ -48,4 +48,12 @@ class StockListMapperTest {
                 .contains(new StockList(1, "メタノール", "HPLC用", 3, "L", LocalDate.of(2023, 5, 24)));
     }
 
+    @Test
+    @DataSet(value = "datasets/stockList.yml")
+    @Transactional
+    void 存在しない在庫を指定した時に空のリストが返されること() {
+        List<StockList> stockList = stockListMapper.findByName("硝酸");
+        assertThat(stockList).isEmpty();
+    }
+
 }


### PR DESCRIPTION
## CRUD処理すべてを備えたREST APIの作成

### 概要

消耗品の在庫一覧についてAPIを作成しました。  
今回は試験研究などで使用される試薬を題材にして在庫一覧表を作成しました。

今回はfindByName()メソッドのDB単体テストになります。
[コミット一覧](https://github.com/sugao-2211/stockListProject/pull/20/commits)

##

これまでの実施結果はこちら
https://github.com/sugao-2211/stockListProject/blob/main/README.md
##

プロジェクトの進捗を作成しました。(作業しながら作成中)
https://github.com/users/sugao-2211/projects/1
今回のタスク： https://github.com/sugao-2211/stockListProject/issues/18#issue-2045019442

##

今回実施箇所
- findByName()メソッドのDB単体テスト
    - 在庫名を指定したときに該当するの在庫情報が取得できること
    - 存在しない在庫を指定したときに空のリストが返されること

  https://github.com/sugao-2211/stockListProject/blob/4a1c4063201ef38414f2568a0cb9ebcdc9b49825/src/test/java/com/stock/stocklist/mapper/StockListMapperTest.java#L42-L58

- 実行結果
    - 在庫名を指定したときに該当するの在庫情報が取得できること
      <img width="1391" alt="スクリーンショット 2023-12-17 16 19 03" src="https://github.com/sugao-2211/stockListProject/assets/141313076/89714d1e-e855-42f9-9c0d-0e2ab244e634">
    - 存在しない在庫を指定したときに空のリストが返されること
      <img width="1383" alt="スクリーンショット 2023-12-17 16 24 05" src="https://github.com/sugao-2211/stockListProject/assets/141313076/fe32ee08-a1d7-4c22-a44f-089751b9fb1f">

##
今回の実施結果を下記のREADMEにも反映しています。
("Read処理の実装"の中にあります。)
https://github.com/sugao-2211/stockListProject/blob/DBtest/findByName/README.md
