### PR TITLE
DBtest（insert update delete）の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ https://github.com/users/sugao-2211/projects/1
     - quantityを文字列で入力した場合
     - quantityを小数で入力した場合
     - purchaseの形式が誤っている場合
+- insert()メソッドのDB単体テスト
+    - insert()メソッドによって新規の在庫情報が登録できること
 
 ##
 
@@ -436,6 +438,22 @@ https://github.com/users/sugao-2211/projects/1
 
 </details>
 
+##
+
+<details>
+<summary>insert()メソッドのDB単体テスト</summary>
+
+- insert()メソッドのDB単体テスト
+    - insert()メソッドによって新規の在庫情報が登録できること
+
+  https://github.com/sugao-2211/stockListProject/blob/fb29b26c3e01b26c6e38412a44cfce8a3f70a3e8/src/test/java/com/stock/stock/mapper/StockMapperTest.java#L78-L88
+
+- 実行結果
+  <img width="1001" alt="スクリーンショット 2024-09-26 22 57 38" src="https://github.com/user-attachments/assets/618ef261-46cb-4566-9ca9-bc983f9c0d8b">
+
+</details>
+
+
 </details>
 
 ***
@@ -470,6 +488,9 @@ https://github.com/users/sugao-2211/projects/1
     - quantityを文字列で入力した場合
     - quantityを小数で入力した場合
     - purchaseの形式が誤っている場合
+- update()メソッドのDB単体テスト
+    - update()メソッドによってidを指定したときに該当する在庫情報が更新できること
+    - 存在しないidを指定したときに在庫情報が更新されないこと
 
 ##
 
@@ -577,6 +598,25 @@ https://github.com/users/sugao-2211/projects/1
 
 </details>
 
+##
+
+<details>
+<summary>update()メソッドのDB単体テスト</summary>
+
+- update()メソッドのDB単体テスト
+    - update()メソッドによってidを指定したときに該当する在庫情報が更新できること
+    - 存在しないidを指定したときに在庫情報が更新されないこと
+
+  https://github.com/sugao-2211/stockListProject/blob/fb29b26c3e01b26c6e38412a44cfce8a3f70a3e8/src/test/java/com/stock/stock/mapper/StockMapperTest.java#L90-L114
+
+- 実行結果
+    - update()メソッドによってidを指定したときに該当する在庫情報が更新できること
+      <img width="1129" alt="スクリーンショット 2024-09-26 23 02 33" src="https://github.com/user-attachments/assets/cad1796d-df52-4454-bad6-68c3f2e354fb">
+    - 存在しないidを指定したときに在庫情報が更新されないこと
+      <img width="1016" alt="スクリーンショット 2024-09-26 23 02 57" src="https://github.com/user-attachments/assets/493a8e05-769a-4576-8099-ae87b3b3a9a1">
+
+</details>
+
 </details>
 
 ***
@@ -592,6 +632,9 @@ https://github.com/users/sugao-2211/projects/1
     - id: 6
 - 例外処理の確認 (NotFoundException)
     - 存在しないデータの削除
+- delete()メソッドのDB単体テスト
+    - delete()メソッドによってidを指定したときに該当する在庫情報が削除できること
+    - 存在しないidを指定したときに在庫情報が削除されないこと
 
 ##
 
@@ -631,6 +674,25 @@ https://github.com/users/sugao-2211/projects/1
     - 存在しないデータの削除(id：99を削除するリクエスト)
 - 実行結果  
   <img width="689" alt="スクリーンショット 2023-11-08 22 44 02" src="https://github.com/sugao-2211/stockListProject/assets/141313076/a959bd7f-0efc-4dda-8599-0af476b6e734">
+
+</details>
+
+##
+
+<details>
+<summary>delete()メソッドのDB単体テスト</summary>
+
+- delete()メソッドのDB単体テスト
+    - delete()メソッドによってidを指定したときに該当する在庫情報が削除できること
+    - 存在しないidを指定したときに在庫情報が削除されないこと
+
+  https://github.com/sugao-2211/stockListProject/blob/fb29b26c3e01b26c6e38412a44cfce8a3f70a3e8/src/test/java/com/stock/stock/mapper/StockMapperTest.java#L116-L136
+
+- 実行結果
+    - delete()メソッドによってidを指定したときに該当する在庫情報が削除できること
+      <img width="955" alt="スクリーンショット 2024-09-26 23 10 25" src="https://github.com/user-attachments/assets/2e3132a8-0d1b-4a84-807a-608c109982b0">
+    - 存在しないidを指定したときに在庫情報が削除されないこと
+      <img width="950" alt="スクリーンショット 2024-09-26 23 12 12" src="https://github.com/user-attachments/assets/cf262c5f-75a1-4f8c-a673-f904be5d0298">
 
 </details>
 

--- a/src/test/java/com/stock/stock/mapper/StockMapperTest.java
+++ b/src/test/java/com/stock/stock/mapper/StockMapperTest.java
@@ -75,4 +75,63 @@ class StockMapperTest {
         assertThat(stockList).isEmpty();
     }
 
+    @Test
+    @DataSet(value = "datasets/stockList.yml")
+    @Transactional
+    void 新しい在庫情報が登録できること() {
+        Stock stock = new Stock(null, "トルエン", "特級", 100, "mL", LocalDate.of(2024, 2, 18));
+        stockListMapper.insert(stock);
+
+        // 結果確認用
+        List<Stock> stocks = stockListMapper.findAll();
+        assertThat(stocks).hasSize(9);
+    }
+
+    @Test
+    @DataSet(value = "datasets/stockList.yml")
+    @Transactional
+    void idを指定したときに該当する在庫情報が更新できること() {
+        Stock stock = new Stock(1, "メタノール", "特級", 3, "L", LocalDate.of(2023, 5, 24));
+        stockListMapper.update(stock);
+
+        // 結果確認用
+        Optional<Stock> stockList = stockListMapper.findById(1);
+        assertThat(stockList)
+                .contains(new Stock(1, "メタノール", "特級", 3, "L", LocalDate.of(2023, 5, 24)));
+    }
+
+    @Test
+    @DataSet(value = "datasets/stockList.yml")
+    @Transactional
+    void 存在しないidを指定したときに在庫情報が更新されないこと() {
+        Stock stock = new Stock(99, "メタノール", "特級", 3, "L", LocalDate.of(2023, 5, 24));
+        stockListMapper.update(stock);
+
+        // 結果確認用
+        Optional<Stock> stockList = stockListMapper.findById(1);
+        assertThat(stockList)
+                .contains(new Stock(1, "メタノール", "HPLC用", 3, "L", LocalDate.of(2023, 5, 24)));
+    }
+
+    @Test
+    @DataSet(value = "datasets/stockList.yml")
+    @Transactional
+    void idを指定したときに該当する在庫情報が削除できること() {
+        stockListMapper.delete(1);
+
+        // 結果確認用
+        List<Stock> stocks = stockListMapper.findAll();
+        assertThat(stocks).hasSize(7);
+    }
+
+    @Test
+    @DataSet(value = "datasets/stockList.yml")
+    @Transactional
+    void 存在しないidを指定したときに在庫情報が削除されないこと() {
+        stockListMapper.delete(99);
+
+        // 結果確認用
+        List<Stock> stocks = stockListMapper.findAll();
+        assertThat(stocks).hasSize(8);
+    }
 }

--- a/src/test/java/com/stock/stock/service/StockServiceTest.java
+++ b/src/test/java/com/stock/stock/service/StockServiceTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -56,14 +57,12 @@ class StockServiceTest {
                 new Stock(2, "塩化カリウム", "特級", 500, "g", LocalDate.parse("2023-07-19")),
                 new Stock(3, "硫酸ナトリウム", "特級", 5, "kg", LocalDate.parse("2023-10-11"))
         );
-
         doReturn(stockList).when(stockListMapper).findAll();
 
         List<Stock> actual = stockListService.findData(null);
         assertThat(actual).isEqualTo(stockList);
         verify(stockListMapper, times(1)).findAll();
         verify(stockListMapper, never()).findByName("メタノール");
-
     }
 
     @Test
@@ -89,4 +88,13 @@ class StockServiceTest {
         verify(stockListMapper, never()).findAll();
     }
 
+    @Test
+    public void 新しい在庫情報が正常に登録処理が実行されること() throws Exception {
+        Stock stock = new Stock(null, "アセトニトリル", "HPLC用", 3, "L", LocalDate.parse("2024-05-13"));
+        doNothing().when(stockListMapper).insert(stock);
+
+        Stock actual = stockListService.insert(stock);
+        assertThat(actual).isEqualTo(stock);
+        verify(stockListMapper, times(1)).insert(stock);
+    }
 }

--- a/src/test/java/com/stock/stock/service/StockServiceTest.java
+++ b/src/test/java/com/stock/stock/service/StockServiceTest.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -57,12 +56,14 @@ class StockServiceTest {
                 new Stock(2, "塩化カリウム", "特級", 500, "g", LocalDate.parse("2023-07-19")),
                 new Stock(3, "硫酸ナトリウム", "特級", 5, "kg", LocalDate.parse("2023-10-11"))
         );
+
         doReturn(stockList).when(stockListMapper).findAll();
 
         List<Stock> actual = stockListService.findData(null);
         assertThat(actual).isEqualTo(stockList);
         verify(stockListMapper, times(1)).findAll();
         verify(stockListMapper, never()).findByName("メタノール");
+
     }
 
     @Test
@@ -88,13 +89,4 @@ class StockServiceTest {
         verify(stockListMapper, never()).findAll();
     }
 
-    @Test
-    public void 新しい在庫情報が正常に登録処理が実行されること() throws Exception {
-        Stock stock = new Stock(null, "アセトニトリル", "HPLC用", 3, "L", LocalDate.parse("2024-05-13"));
-        doNothing().when(stockListMapper).insert(stock);
-
-        Stock actual = stockListService.insert(stock);
-        assertThat(actual).isEqualTo(stock);
-        verify(stockListMapper, times(1)).insert(stock);
-    }
 }


### PR DESCRIPTION
## CRUD処理すべてを備えたREST APIの作成

### 概要

消耗品の在庫一覧についてAPIを作成しました。  
今回は試験研究などで使用される試薬を題材にして在庫一覧表を作成しました。

今回はDB単体テスト(insert/update/delete)になります。
該当コミット： fb29b26c3e01b26c6e38412a44cfce8a3f70a3e8

##

これまでの実施結果はこちら
https://github.com/sugao-2211/stockListProject/blob/main/README.md
##

プロジェクトの進捗を作成しました。(作業しながら作成中)
https://github.com/users/sugao-2211/projects/1
今回のタスク： https://github.com/sugao-2211/stockListProject/issues/33#issue-2195140668

##

今回実施箇所
DB単体テスト(insert/update/delete)

- insertメソッド(Create処理)
    - 新規の在庫情報が登録できること

- updateメソッド(Update処理)
    - idを指定したときに該当する在庫情報が更新できること
    - 存在しないidを指定したときに在庫情報が更新されないこと

- deleteメソッド(Delete処理)
    - idを指定したときに該当する在庫情報が削除できること
    - 存在しないidを指定したときに在庫情報が削除されないこと

##
実装内容
      https://github.com/sugao-2211/stockListProject/blob/fb29b26c3e01b26c6e38412a44cfce8a3f70a3e8/src/test/java/com/stock/stock/mapper/StockMapperTest.java#L78-L136

- 実行結果
    - 新規の在庫情報が登録できること
       <img width="1001" alt="スクリーンショット 2024-09-26 22 57 38" src="https://github.com/user-attachments/assets/618ef261-46cb-4566-9ca9-bc983f9c0d8b">

    - idを指定したときに該当する在庫情報が更新できること
       <img width="1129" alt="スクリーンショット 2024-09-26 23 02 33" src="https://github.com/user-attachments/assets/cad1796d-df52-4454-bad6-68c3f2e354fb">

    - 存在しないidを指定したときに在庫情報が更新されないこと
       <img width="1016" alt="スクリーンショット 2024-09-26 23 02 57" src="https://github.com/user-attachments/assets/493a8e05-769a-4576-8099-ae87b3b3a9a1">

    - idを指定したときに該当する在庫情報が削除できること
       <img width="955" alt="スクリーンショット 2024-09-26 23 10 25" src="https://github.com/user-attachments/assets/2e3132a8-0d1b-4a84-807a-608c109982b0">

    - 存在しないidを指定したときに在庫情報が削除されないこと
       <img width="950" alt="スクリーンショット 2024-09-26 23 12 12" src="https://github.com/user-attachments/assets/cf262c5f-75a1-4f8c-a673-f904be5d0298">


##
今回の実施結果を下記のREADMEにも反映しています。
https://github.com/sugao-2211/stockListProject/blob/dbtest/insert-update-delete/README.md